### PR TITLE
Makes the raw_message field LONGTEXT

### DIFF
--- a/lib/generators/letter_thief/templates/create_email_messages.rb.erb
+++ b/lib/generators/letter_thief/templates/create_email_messages.rb.erb
@@ -21,7 +21,7 @@ class CreateLetterThiefEmailMessages < ActiveRecord::Migration<%= migration_vers
       t.text :body_text
       t.text :body_html
       t.text :headers
-      t.text :raw_message
+      t.text :raw_message, limit: 4294967295
       t.string :content_type
       t.datetime :intercepted_at
 


### PR DESCRIPTION
Fixes #10. Why overthink it when storage is cheap?