### PR TITLE
Must remove style nonce directive to allow unsafe_inline

### DIFF
--- a/app/controllers/letter_thief/email_messages_controller.rb
+++ b/app/controllers/letter_thief/email_messages_controller.rb
@@ -6,8 +6,8 @@ module LetterThief
 
     content_security_policy do |policy|
       policy.style_src :self, :https, :unsafe_inline
-      policy.content_security_policy_nonce_directives = []
     end
+    Rails.application.config.content_security_policy_nonce_directives = []
 
     PAGE_SIZE = 20
 

--- a/app/controllers/letter_thief/email_messages_controller.rb
+++ b/app/controllers/letter_thief/email_messages_controller.rb
@@ -6,6 +6,7 @@ module LetterThief
 
     content_security_policy do |policy|
       policy.style_src :self, :https, :unsafe_inline
+      policy.content_security_policy_nonce_directives = []
     end
 
     PAGE_SIZE = 20


### PR DESCRIPTION
Thanks for addressing the CSP issue. I agree that since it shouldn't be for the general public, unsafe inline should be fine. However, a common CSP setting is using nonces to allow exceptions, and when using nonces alongside policies, `unsafe_inline` is ignored if nonces are enabled. See relevant browser output:

```
Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self' https: 'unsafe-inline' 'nonce-711957990c8910426dbb206c16fd2dee'".
Note that 'unsafe-inline' is ignored if either a hash or nonce value is present in the source list.
```

This PR overrides the applications nonce setting to turn it off, thereby preventing the above issue. Should be an entirely safe change.
