### PR TITLE
#21 - save email after sending out

### DIFF
--- a/lib/letter_thief/engine.rb
+++ b/lib/letter_thief/engine.rb
@@ -1,13 +1,13 @@
-require "letter_thief/interceptor"
+require "letter_thief/observer"
 require "letter_thief/delivery_method"
 
 module LetterThief
   class Engine < ::Rails::Engine
     isolate_namespace LetterThief
 
-    initializer "letter_thief.add_interceptor" do
+    initializer "letter_thief.add_observer" do
       ActiveSupport.on_load(:action_mailer) do
-        ActionMailer::Base.register_interceptor(LetterThief::Interceptor)
+        ActionMailer::Base.register_observer(LetterThief::Observer)
       end
     end
 

--- a/lib/letter_thief/observer.rb
+++ b/lib/letter_thief/observer.rb
@@ -1,6 +1,6 @@
 module LetterThief
-  class Interceptor
-    def self.delivering_email(mail)
+  class Observer
+    def self.delivered_email(mail)
       string_io = StringIO.new(mail.to_s)
       email = EmailMessage.create!(
         to: mail.to,

--- a/test/observer_test.rb
+++ b/test/observer_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 module LetterThief
-  class InterceptorTest < ActiveSupport::TestCase
+  class ObserverTest < ActiveSupport::TestCase
     test "creates an EmailMessage from a basic email" do
       mail = Mail.new do
         from "sender@example.com"
@@ -11,7 +11,7 @@ module LetterThief
       end
 
       assert_difference -> { EmailMessage.count }, 1 do
-        Interceptor.delivering_email(mail)
+        Observer.delivered_email(mail)
       end
 
       email = EmailMessage.last
@@ -41,7 +41,7 @@ module LetterThief
         end
       end
 
-      Interceptor.delivering_email(mail)
+      Observer.delivered_email(mail)
       email = EmailMessage.last
 
       assert_equal "Plain version", email.body_text
@@ -58,7 +58,7 @@ module LetterThief
         add_file(filename: "test.txt", content: "This is a test file")
       end
 
-      Interceptor.delivering_email(mail)
+      Observer.delivered_email(mail)
 
       email = EmailMessage.last
       assert_equal email.attachments.length, 1


### PR DESCRIPTION
https://guides.rubyonrails.org/action_mailer_basics.html#intercepting-and-observing-emails

> Interceptors allow you to make modifications to emails before they are handed off to the delivery agents
> Observers give you access to the email message after it has been sent.

Since the purpose of this gem is to save the content of sent emails rather than modify them beforehand, switching from `interceptors` to `observers` appears to be the more appropriate choice.

Test locally and no issue to save emails as before

address the issue #21 