### PR TITLE
Fix NoMethodError in helper 'parsed_body_html'

### DIFF
--- a/app/helpers/letter_thief/application_helper.rb
+++ b/app/helpers/letter_thief/application_helper.rb
@@ -2,9 +2,10 @@ module LetterThief
   module ApplicationHelper
     def parsed_body_html(email)
       rendered = email.body_html
-      email.attachments.each do |attachment|
-        puts attachment.blob.metadata["cid"]
-        rendered.gsub!("cid:#{attachment.blob.metadata["cid"]}", main_app.rails_blob_path(attachment))
+      if LetterThief.activestorage_available?
+        email.attachments.each do |attachment|
+          rendered.gsub!("cid:#{attachment.blob.metadata["cid"]}", main_app.rails_blob_path(attachment))
+        end
       end
       # autolinking can be implemented for text bodies
       # rendered.gsub!(URI::Parser.new.make_regexp(%W[https http])) do |link|


### PR DESCRIPTION
`email` does not respond to `attachments` if `LetterThief.activestorage_available?` is `false`:
https://github.com/coorasse/letter_thief/blob/308ce2902efb9c2c1b7e7c129566d042188292e0/app/models/letter_thief/email_message.rb#L7-L8