### PR TITLE
fix: deliver emails when launchy is not installed

### DIFF
--- a/lib/letter_thief/delivery_method.rb
+++ b/lib/letter_thief/delivery_method.rb
@@ -6,8 +6,9 @@ module LetterThief
     end
 
     def deliver!(mail)
+      delivered_mail = Observer.delivered_email(mail)
       require "launchy"
-      ::Launchy.open(LetterThief::Engine.routes.url_helpers.email_message_url(Observer.delivered_email(mail), Rails.configuration.action_mailer.default_url_options))
+      ::Launchy.open(LetterThief::Engine.routes.url_helpers.email_message_url(delivered_mail, Rails.configuration.action_mailer.default_url_options))
     rescue LoadError
       puts "WARNING: LetterThief requires the 'launchy' gem to open the email in a web browser. Add it to your Gemfile."
     end


### PR DESCRIPTION
Ensure email is persisted before absence of `launchy`

Details in https://github.com/coorasse/letter_thief/issues/73